### PR TITLE
fixed broken merge, added test for merge

### DIFF
--- a/src/Common/Select.php
+++ b/src/Common/Select.php
@@ -1099,7 +1099,6 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
         // remove basic FROM
         unset($from[0]);
         return array(
-            'cols' => $this->cols,
             'from' => $from,
             'where' => $this->where,
             'group_by' => $this->group_by,
@@ -1114,12 +1113,10 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
      */
     public function merge(array $mergeDetails)
     {
-        if (!empty($mergeDetails['cols'])) {
-            $this->cols = array_merge($this->cols, $mergeDetails['cols']);
-        }
         $this->from[$this->from_key] = array_merge($this->from[$this->from_key], $mergeDetails['from']);
         if (!empty($mergeDetails['where'])) {
-            $this->addClauseCondWithBind('where', 'AND', $mergeDetails['where']);
+            $this->where[] = (count($this->where) ?  "AND " : '')  . array_shift($mergeDetails['where']);
+            $this->where = array_merge($this->where, $mergeDetails['where']);
         }
         $this->bind_values = array_replace($this->bind_values, $mergeDetails['bind_values']);
 
@@ -1127,7 +1124,8 @@ class Select extends AbstractQuery implements SelectInterface, SubselectInterfac
             $this->group_by = array_merge($this->group_by, $mergeDetails['group_by']);
         }
         if (!empty($mergeDetails['having'])) {
-            $this->addClauseCondWithBind('having', 'AND', $mergeDetails['having']);
+            $this->having[] = (count($this->having) ?  "AND " : '')  . array_shift($mergeDetails['having']);
+            $this->having = array_merge($this->having, $mergeDetails['having']);
         }
 
     }

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -504,7 +504,8 @@ class SelectTest extends AbstractQueryTest
     public function testMerge()
     {
         $this->query->cols(array('*'))
-            ->from('t1')
+            ->from('t10')
+            ->join('left', 't11', 't10.id = t11.id')
             ->where('c101 = c102')
             ->where('c103 = ?', 'foo')
             ->groupBy(array('c104', 'c105'))
@@ -513,8 +514,8 @@ class SelectTest extends AbstractQueryTest
 
         $merge = array(
             'from' => array(
-                'INNER JOIN t2',
-                'LEFT JOIN t3',
+                'INNER JOIN t20',
+                'LEFT JOIN t21',
             ),
             'where' => array(
                 'c201 = c202',
@@ -537,11 +538,12 @@ class SelectTest extends AbstractQueryTest
         $actual = $this->query->__toString();
         $expect = '
             SELECT
-                <<t1>>.*
+                <<t10>>.*
             FROM
-                <<t1>>
-                INNER JOIN t2
-                LEFT JOIN t3
+                <<t10>>
+                LEFT JOIN <<t11>> ON <<t10>>.<<id>> = <<t11>>.<<id>>
+                INNER JOIN t20
+                LEFT JOIN t21
             WHERE
                 c101 = c102
                 AND c103 = :_1_

--- a/tests/Common/SelectTest.php
+++ b/tests/Common/SelectTest.php
@@ -501,6 +501,73 @@ class SelectTest extends AbstractQueryTest
         $this->assertSame($expect, $actual);
     }
 
+    public function testMerge()
+    {
+        $this->query->cols(array('*'))
+            ->from('t1')
+            ->where('c101 = c102')
+            ->where('c103 = ?', 'foo')
+            ->groupBy(array('c104', 'c105'))
+            ->having('c106 = c107')
+            ->having('c108 = c109');
+
+        $merge = array(
+            'from' => array(
+                'INNER JOIN t2',
+                'LEFT JOIN t3',
+            ),
+            'where' => array(
+                'c201 = c202',
+                'AND c203 = c204',
+            ),
+            'bind_values' => array(
+                'c205' => 'foo',
+            ),
+            'group_by' => array(
+                'c206',
+                'c207',
+            ),
+            'having' => array(
+                'c208 = c209',
+                'AND c210 = c211',
+            ),
+        );
+        $this->query->merge($merge);
+
+        $actual = $this->query->__toString();
+        $expect = '
+            SELECT
+                <<t1>>.*
+            FROM
+                <<t1>>
+                INNER JOIN t2
+                LEFT JOIN t3
+            WHERE
+                c101 = c102
+                AND c103 = :_1_
+                AND c201 = c202
+                AND c203 = c204
+            GROUP BY
+                c104,
+                c105,
+                c206,
+                c207
+            HAVING
+                c106 = c107
+                AND c108 = c109
+                AND c208 = c209
+                AND c210 = c211
+        ';
+        $this->assertSameSql($expect, $actual);
+
+        $actual = $this->query->getBindValues();
+        $expect = array(
+            '_1_' => 'foo',
+            'c205' => 'foo',
+        );
+        $this->assertSame($expect, $actual);
+    }
+
     public function testOrWhere()
     {
         $this->query->cols(array('*'));


### PR DESCRIPTION
1) removed processing cols() in merge: now it's not required, and the existing implementation does not handle case when both queries have * in cols(): array_merge is not OK in this case: the result is two times *. should be handled in smart way.
2) fixed wrong merge of where and having in case more than 1 condition, added tests for that.